### PR TITLE
Add configurable LLM factory and model selector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: pip install -r requirements.txt
+      - run: pytest
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - run: cd frontend && npm ci && npm test -- --watchAll=false

--- a/README.md
+++ b/README.md
@@ -55,22 +55,36 @@ TESTIA/
 4. **Acceder Web UI**:
    - Abrir http://localhost:8080
 
-## Configuración de Modelos Custom
+## Configuración de Modelos
 
-Edita `config/models.json` para agregar tus modelos:
+Los modelos disponibles se definen en `models.config.json`. Cada entrada
+incluye:
+  - `provider`: nombre del servicio o tipo de modelo
+  - `api_key`: credencial asociada (opcional)
+  - `endpoint`: URL o ruta local del modelo
+  - `parameters`: configuración de temperatura, máximo de tokens, etc.
+
+Ejemplo con dos proveedores:
 
 ```json
 {
   "models": {
-    "custom-gpt": {
+    "gpt-4": {
       "provider": "openai",
-      "model": "gpt-4",
       "api_key": "${OPENAI_API_KEY}",
-      "instructions": "Eres un asistente especializado..."
+      "endpoint": "https://api.openai.com/v1",
+      "parameters": {"temperature": 0.7, "max_tokens": 4000}
+    },
+    "local-llama": {
+      "provider": "custom",
+      "endpoint": "http://localhost:11434/v1",
+      "parameters": {"temperature": 0.7, "max_tokens": 2000}
     }
   }
 }
 ```
+
+Para añadir un nuevo modelo simplemente agrega otra sección siguiendo la misma estructura.
 
 ## MCP Support
 

--- a/frontend/__tests__/ChatCanvas.test.jsx
+++ b/frontend/__tests__/ChatCanvas.test.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ChatCanvas from '../src/components/ChatCanvas';
+
+test('shows model badge per message', () => {
+  const msgs = [{ text: 'hi', model: 'gpt-4' }];
+  render(<ChatCanvas messages={msgs} />);
+  expect(screen.getByTestId('model-badge').textContent).toContain('gpt-4');
+});

--- a/frontend/__tests__/ModelSelector.test.jsx
+++ b/frontend/__tests__/ModelSelector.test.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import ModelSelector from '../src/components/ModelSelector';
+
+beforeEach(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ json: () => Promise.resolve({ models: ['a', 'b'] }) })
+  );
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('loads models and renders options', async () => {
+  render(<ModelSelector onChange={() => {}} />);
+  await waitFor(() => screen.getByTestId('model-select'));
+  expect(screen.getAllByRole('option').length).toBe(3); // including placeholder
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "testia-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "jest"
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "14.1.2",
+    "jest": "29.7.0",
+    "babel-jest": "29.7.0",
+    "@babel/preset-env": "7.22.20",
+    "@babel/preset-react": "7.22.5"
+  },
+  "jest": {
+    "testEnvironment": "jsdom",
+    "transform": {
+      "^.+\\.jsx?$": "babel-jest"
+    }
+  },
+  "babel": {
+    "presets": ["@babel/preset-env", "@babel/preset-react"]
+  }
+}

--- a/frontend/src/components/ChatCanvas.jsx
+++ b/frontend/src/components/ChatCanvas.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function ChatCanvas({ messages }) {
+  return (
+    <ul>
+      {messages.map((m, idx) => (
+        <li key={idx}>
+          <span>{m.text}</span>
+          {m.model && <span data-testid="model-badge"> [{m.model}]</span>}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/components/ModelSelector.jsx
+++ b/frontend/src/components/ModelSelector.jsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from 'react';
+
+export default function ModelSelector({ onChange }) {
+  const [models, setModels] = useState([]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/models-config');
+        const data = await res.json();
+        setModels(data.models || []);
+      } catch (e) {
+        console.error('Failed to load models', e);
+      }
+    }
+    load();
+  }, []);
+
+  return (
+    <select onChange={e => onChange(e.target.value)} data-testid="model-select">
+      <option value="">Choose model</option>
+      {models.map(m => (
+        <option key={m} value={m}>{m}</option>
+      ))}
+    </select>
+  );
+}

--- a/models.config.json
+++ b/models.config.json
@@ -1,0 +1,22 @@
+{
+  "models": {
+    "gpt-4": {
+      "provider": "openai",
+      "api_key": "${OPENAI_API_KEY}",
+      "endpoint": "https://api.openai.com/v1",
+      "parameters": {
+        "temperature": 0.7,
+        "max_tokens": 4000
+      }
+    },
+    "local-llama": {
+      "provider": "custom",
+      "api_key": null,
+      "endpoint": "http://localhost:11434/v1",
+      "parameters": {
+        "temperature": 0.7,
+        "max_tokens": 2000
+      }
+    }
+  }
+}

--- a/src/llm_connector/factory.py
+++ b/src/llm_connector/factory.py
@@ -1,0 +1,75 @@
+import json
+import os
+import logging
+from typing import Any, Dict
+
+from src.models.manager import (
+    ModelProvider,
+    ModelConfig,
+    OpenAIProvider,
+    AnthropicProvider,
+    HuggingFaceProvider,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ModelFactory:
+    """Factory that builds model clients from a configuration file."""
+
+    def __init__(self, config_path: str = "models.config.json"):
+        """Initialize the factory and load model configurations."""
+        self.config_path = config_path
+        self.configs: Dict[str, ModelConfig] = {}
+        self._load_config()
+
+    def _load_config(self) -> None:
+        """Load all model configurations from ``self.config_path``."""
+        if not os.path.exists(self.config_path):
+            raise FileNotFoundError(f"Config file not found: {self.config_path}")
+
+        with open(self.config_path, "r") as f:
+            data = json.load(f)
+
+        for name, cfg in data.get("models", {}).items():
+            parameters = cfg.get("parameters", {})
+            model_cfg = ModelConfig(
+                name=name,
+                provider=ModelProvider(cfg["provider"]),
+                model_id=cfg.get("model_id", name),
+                api_key=cfg.get("api_key"),
+                api_base=cfg.get("endpoint"),
+                max_tokens=parameters.get("max_tokens", 4000),
+                temperature=parameters.get("temperature", 0.7),
+                custom_parameters={k: v for k, v in parameters.items() if k not in {"max_tokens", "temperature"}},
+            )
+            self.configs[name] = model_cfg
+        logger.info("Loaded %s model configurations", len(self.configs))
+
+    async def get_client(self, model_name: str):
+        """Return an initialized provider for ``model_name``.
+
+        Parameters
+        ----------
+        model_name: str
+            Identifier of the model as defined in the configuration file.
+        """
+        if model_name not in self.configs:
+            raise ValueError(f"Unknown model: {model_name}")
+
+        config = self.configs[model_name]
+        provider = self._create_provider(config)
+        await provider.initialize()
+        return provider
+
+    def _create_provider(self, config: ModelConfig):
+        """Instantiate the correct provider implementation."""
+        if config.provider == ModelProvider.OPENAI:
+            return OpenAIProvider(config)
+        if config.provider == ModelProvider.ANTHROPIC:
+            return AnthropicProvider(config)
+        if config.provider == ModelProvider.HUGGINGFACE:
+            return HuggingFaceProvider(config)
+        # Custom/unknown provider handled as OpenAI-compatible HTTP API
+        return OpenAIProvider(config)
+

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -1,0 +1,54 @@
+"""FastAPI application for TESTIA."""
+import logging
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from src.llm_connector.factory import ModelFactory
+
+app = FastAPI(title="TESTIA API")
+logger = logging.getLogger(__name__)
+
+model_factory: Optional[ModelFactory] = None
+
+
+class ChatRequest(BaseModel):
+    message: str
+    model: str
+    conversation_id: Optional[str] = None
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    global model_factory
+    model_factory = ModelFactory()
+    logger.info("Model factory loaded")
+
+
+@app.post("/api/chat")
+async def chat_endpoint(data: ChatRequest):
+    """Generate a response using the requested model."""
+    if model_factory is None:
+        raise HTTPException(status_code=503, detail="Model factory not ready")
+    try:
+        provider = await model_factory.get_client(data.model)
+        messages = [{"role": "user", "content": data.message}]
+        response = await provider.generate_response(messages)
+        return {"response": response, "model": data.model}
+    except Exception as exc:
+        logger.error("Chat error: %s", exc)
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@app.get("/api/models-config")
+async def models_config():
+    if model_factory is None:
+        raise HTTPException(status_code=503, detail="Model factory not ready")
+    return {"models": list(model_factory.configs.keys())}
+
+
+def run_web_server(host: str = "0.0.0.0", port: int = 8080) -> None:
+    import uvicorn
+
+    uvicorn.run(app, host=host, port=port)

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -1,0 +1,41 @@
+import json
+from pathlib import Path
+from unittest import mock
+import pytest
+
+from src.llm_connector.factory import ModelFactory
+
+
+sample_config = {
+    "models": {
+        "x": {
+            "provider": "openai",
+            "api_key": "sk-test",
+            "endpoint": "https://api.example.com",
+            "parameters": {"temperature": 0.5, "max_tokens": 10}
+        }
+    }
+}
+
+
+def test_load_config(tmp_path: Path):
+    cfg_file = tmp_path / "models.json"
+    cfg_file.write_text(json.dumps(sample_config))
+    factory = ModelFactory(str(cfg_file))
+    assert "x" in factory.configs
+    cfg = factory.configs["x"]
+    assert cfg.temperature == 0.5
+    assert cfg.max_tokens == 10
+
+
+@pytest.mark.asyncio
+async def test_get_client_initializes(tmp_path: Path):
+    cfg_file = tmp_path / "models.json"
+    cfg_file.write_text(json.dumps(sample_config))
+    factory = ModelFactory(str(cfg_file))
+    with mock.patch("src.models.manager.OpenAIProvider.initialize") as init_mock:
+        init_mock.return_value = None
+        client = await factory.get_client("x")
+        init_mock.assert_called_once()
+        assert client is not None
+


### PR DESCRIPTION
## Summary
- provide example `models.config.json`
- implement `ModelFactory` under `llm_connector`
- add FastAPI `/api/chat` endpoint using selected model
- create simple React components `ModelSelector` and `ChatCanvas`
- add unit tests and GitHub Actions workflow
- update README with configuration instructions

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6877ed3b22b483338c75f1acf0c97746